### PR TITLE
Check server lobby data before claiming new prompts or submitting prompt text #15

### DIFF
--- a/src/components/PlayerForm/PlayerForm.tsx
+++ b/src/components/PlayerForm/PlayerForm.tsx
@@ -19,7 +19,7 @@ const PlayerForm = () => {
     getLobbyData(state.lobby.code).then(async serverLobby => {
       const claimed_prompt: PromptFragment = serverLobby.prompts.find((prompt) =>
         isClaimedPrompt(prompt, state.player.id)
-      )
+      ) as PromptFragment
       claimed_prompt.status = "open"
       claimed_prompt.claimed_by.color = ""
       claimed_prompt.claimed_by.id = ""

--- a/src/components/PlayerForm/PlayerForm.tsx
+++ b/src/components/PlayerForm/PlayerForm.tsx
@@ -2,7 +2,7 @@ import { useState, ChangeEvent, FormEvent } from "react";
 import PromptClaim from "./PromptClaim";
 import styles from "@/styles/PlayerForm.module.css";
 import { useUserData } from "@/helpers/UserProvider";
-import { PromptFragment } from "../../../types";
+import { PromptFragment, Player } from "../../../types";
 import NameForm from "../NameForm";
 import { getClaimedPrompt, isClaimedPrompt, moderatePrompt } from "@/helpers/promptActions";
 import { getLobbyData, updateLobby, maybeGeneratingPhase } from "@/helpers/lobbyActions";
@@ -14,6 +14,18 @@ const PlayerForm = () => {
   const [isFlagged, setIsFlagged] = useState(false);
   const handleBlur = async () => {
     moderatePrompt(promptSubmission).then(flagged => setIsFlagged(flagged))
+  }
+  const unclaimPrompt = async () => {
+    getLobbyData(state.lobby.code).then(async serverLobby => {
+      const claimed_prompt: PromptFragment = serverLobby.prompts.find((prompt) =>
+        isClaimedPrompt(prompt, state.player.id)
+      )
+      claimed_prompt.status = "open"
+      claimed_prompt.claimed_by.color = ""
+      claimed_prompt.claimed_by.id = ""
+      claimed_prompt.claimed_by.name = ""
+      await updateLobby(serverLobby);
+    })
   }
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -81,6 +93,8 @@ const PlayerForm = () => {
           {isFlagged ? <><button className="button" onClick={()=> {setPromptSumbission(""); setIsFlagged(false);}}>no thanks. try again</button><p>the robots think you&apos;re being inappropriate</p></> : <button type="submit" className={`button bg-${state.player.color}`}>
             {loading ? "sending..." : "3 • send it over"}
           </button>}
+          <p className={styles.separator}>—or—</p>
+          <button type="button" className={`button ${styles.unclaim}`} onClick={() => unclaimPrompt()}>relinquish thy claim</button>
         </>: ""}
       </form>
     );

--- a/src/components/PlayerForm/PlayerForm.tsx
+++ b/src/components/PlayerForm/PlayerForm.tsx
@@ -10,6 +10,7 @@ import { getLobbyData, updateLobby, maybeGeneratingPhase } from "@/helpers/lobby
 const PlayerForm = () => {
   const { state, dispatch } = useUserData();
   const [promptSubmission, setPromptSumbission] = useState("");
+  const [loading, setLoading] = useState(false);
   const [isFlagged, setIsFlagged] = useState(false);
   const handleBlur = async () => {
     moderatePrompt(promptSubmission).then(flagged => setIsFlagged(flagged))
@@ -17,6 +18,7 @@ const PlayerForm = () => {
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
     moderatePrompt(promptSubmission).then(async flagged => {
+      setLoading(true);
       setIsFlagged(flagged);
       if (!flagged) {
         const player_id = state.player.id as string;
@@ -33,6 +35,7 @@ const PlayerForm = () => {
           });
         })
       }
+      setLoading(false);
     });
   };
   if (!state.player.id) return <NameForm />;
@@ -76,7 +79,7 @@ const PlayerForm = () => {
             />
           </label>
           {isFlagged ? <><button className="button" onClick={()=> {setPromptSumbission(""); setIsFlagged(false);}}>no thanks. try again</button><p>the robots think you&apos;re being inappropriate</p></> : <button type="submit" className={`button bg-${state.player.color}`}>
-            3 • send it over
+            {loading ? "sending..." : "3 • send it over"}
           </button>}
         </>: ""}
       </form>

--- a/src/components/PlayerForm/PromptClaim.tsx
+++ b/src/components/PlayerForm/PromptClaim.tsx
@@ -72,7 +72,7 @@ const PromptClaim = ({
         checked={claimedByPlayer}
         name="wordClaim"
         onChange={() => claimWord(state, dispatch, arrayIndex as number, setLoading)}
-        value="Adjective"
+        value={type}
         disabled={shouldBeDisabled}
       />
       {type}

--- a/src/components/PlayerForm/PromptClaim.tsx
+++ b/src/components/PlayerForm/PromptClaim.tsx
@@ -1,6 +1,8 @@
 import { Context, Player, PromptFragment } from "../../../types";
+import { useState } from "react";
 import { useUserData } from "@/helpers/UserProvider";
 import { updatePrompt } from "@/helpers/promptActions";
+import { getLobbyData } from "@/helpers/lobbyActions";
 import styles from '@/styles/PromptClaim.module.css'
 
 type PromptClaimInterface = {
@@ -16,25 +18,35 @@ const claimWord = async (
   state: Context,
   // TODO: Refine dispatch type
   dispatch: any,
-  arrayIndex: number
+  arrayIndex: number,
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
+  setLoading(true);
   const player = state.player as Player;
-  state.lobby.prompts.forEach((prompt) => {
-    if (typeof(prompt) == "object" && prompt.status === "claimed" && prompt.claimed_by.id === state.player.id) {
-      prompt.status = "open";
-      prompt.claimed_by = {
-        name: "",
-        color: "",
-        id: ""
-      };
-      prompt.text = "";
+  getLobbyData(state.lobby.code).then(async serverLobby => {
+    const serverPrompt = serverLobby.prompts[arrayIndex] as PromptFragment
+    if (serverPrompt.status == "open") {
+      state.lobby.prompts.forEach((prompt) => {
+        if (typeof(prompt) == "object" && prompt.status === "claimed" && prompt.claimed_by.id === state.player.id) {
+          prompt.status = "open";
+          prompt.claimed_by = {
+            name: "",
+            color: "",
+            id: ""
+          };
+          prompt.text = "";
+        }
+      });
+      const newPrompt = state.lobby.prompts[arrayIndex] as PromptFragment;
+      newPrompt.status = "claimed";
+      newPrompt.claimed_by = player;
+      dispatch({ type: "SET_LOBBY_DATA", payload: state.lobby });
+      await updatePrompt(state.lobby, newPrompt, arrayIndex);
+    } else {
+      dispatch({ type: "SET_LOBBY_DATA", payload: serverLobby });
     }
-  });
-  const newPrompt = state.lobby.prompts[arrayIndex] as PromptFragment;
-  newPrompt.status = "claimed";
-  newPrompt.claimed_by = player;
-  dispatch({ type: "SET_LOBBY_DATA", payload: state.lobby });
-  await updatePrompt(state.lobby, newPrompt, arrayIndex);
+  })
+  setLoading(false)
 };
 
 const PromptClaim = ({
@@ -45,6 +57,7 @@ const PromptClaim = ({
   arrayIndex,
 }: PromptClaimInterface) => {
   const { state, dispatch } = useUserData();
+  const [loading, setLoading] = useState(false);
   const claimedByPlayer = state.player.id === claimed_by_id;
   const shouldBeDisabled =
     (status === "claimed" && !claimedByPlayer) || status === "submitted";
@@ -58,7 +71,7 @@ const PromptClaim = ({
         type="radio"
         checked={claimedByPlayer}
         name="wordClaim"
-        onChange={() => claimWord(state, dispatch, arrayIndex as number)}
+        onChange={() => claimWord(state, dispatch, arrayIndex as number, setLoading)}
         value="Adjective"
         disabled={shouldBeDisabled}
       />

--- a/src/helpers/lobbyActions.ts
+++ b/src/helpers/lobbyActions.ts
@@ -4,7 +4,7 @@ import { compilePrompt, moderatePrompt, randomNewPrompt } from "./promptActions"
 
 export const getLobbyData = async (
   lobbyCode: string
-): Promise<Lobby | ErrorEvent> => {
+): Promise<Lobby> => {
   try {
     let { data, error, status } = await supabase
       .from("lobby")

--- a/src/styles/PlayerForm.module.css
+++ b/src/styles/PlayerForm.module.css
@@ -52,3 +52,13 @@
 .wordClaims label.claimedByPlayer {
   background: var(--player-color);
 }
+
+.separator {
+  font-size: .75rem;
+  text-align: center;
+}
+
+.playerForm .unclaim {
+  font-size: .7rem;
+  padding: 8px;
+}


### PR DESCRIPTION
These commits should prevent a couple pretty serious desync issues found when playtesting last Friday with 5 people on a bad network, as described in #15, by checking the server's lobby data before sending the client updates over.

For claiming prompts, this checks to see if that prompt is actually open - if so, go ahead and claim as before. If not, then it's either claimed or submitted, so just update the client's lobby data to show that pre-existing claim.

For submitting prompt text, this fetches the server's current lobby data at the time of submission, adds the prompt submission data to the server's lobby data, and sends it back over to the server.