### PR TITLE
Change: Use button style for prompt fragments.

### DIFF
--- a/src/components/FormattedPrompt.tsx
+++ b/src/components/FormattedPrompt.tsx
@@ -15,10 +15,10 @@ const PromptFragmentHtml = (promptFragment: PromptFragment | string, index: numb
   if (typeof promptFragment === "string") return <span className={styles.static} key={index}>{maybeTrimPrompt(promptFragment)}</span>;
   else {
     return (
-      <div className={`${styles.dynamic}  border-${promptFragment.claimed_by.color}`} key={index}>
-        <span className={`${styles.claimed_by} bg-${promptFragment.claimed_by.color}`}>{promptFragment.claimed_by.name}</span>
-        <span className={`${styles.text} bg-${promptFragment.claimed_by.color}`}>{promptFragment.text}</span>
-        <span className={`${styles.type} bg-${promptFragment.claimed_by.color}`}>{promptFragment.type}</span>
+      <div className={`${styles.dynamic} button  bg-${promptFragment.claimed_by.color}`} key={index}>
+        <span className={styles.claimed_by}>{promptFragment.claimed_by.name}</span>
+        <span className={styles.text}>{promptFragment.text}</span>
+        <span className={styles.type}>{promptFragment.type}</span>
       </div>
     );
   }

--- a/src/styles/FormattedPrompt.module.css
+++ b/src/styles/FormattedPrompt.module.css
@@ -24,7 +24,6 @@
 }
 .dynamic .text {
   display: inline-block;
-  text-decoration: underline;
 }
 
 .dynamic .type {

--- a/src/styles/FormattedPrompt.module.css
+++ b/src/styles/FormattedPrompt.module.css
@@ -2,6 +2,10 @@
   max-width: 60ch;
   margin: 24px auto;
   font-size: clamp(1rem, 1.5rem, 3vw);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px 0;
 }
 .dynamic, .static {
   font-family: monospace;
@@ -14,15 +18,9 @@
   align-items: center;
 }
 
-.dynamic > * {
-  background-clip: text;
-  -webkit-background-clip: text;
-  color: transparent;
-}
+
 .dynamic .claimed_by {
   font-size: .55em;
-  position: absolute;
-  top: -.75em;
 }
 .dynamic .text {
   display: inline-block;


### PR DESCRIPTION
This makes the FormattedPrompt component use the button-type styling to display prompts people have submitted, using the player's color as the background and either white or black as the text color, whichever has higher color contrast.

![Screenshot of new FormattedPrompt styling](https://github.com/wingmatt/blatherbrush-nextjs/assets/20592216/b493b2c1-26b6-41cf-8311-c5c57a69e3d4)


